### PR TITLE
Decode publisher name from URL

### DIFF
--- a/server/client/ui/endpoints.js
+++ b/server/client/ui/endpoints.js
@@ -8,7 +8,15 @@ var router = require('basis.router');
 var Endpoint = require('../type.js').Endpoint;
 var Publisher = require('../type.js').Publisher;
 
-var selectedId = new Value();
+var selectedId = new Value({
+    proxy: function(value) {
+        if (value) {
+            return decodeURIComponent(value);
+        }
+
+        return value;
+    }
+});
 var pickMode = new Value({ value: false });
 var selectedPublisher = selectedId.as(Publisher.getSlot);
 var selectedEndpoint = selectedPublisher.query('data.endpointId').as(Endpoint.getSlot);


### PR DESCRIPTION
Publisher name in UI is getting from URL.
If publisher name has non-URI characters (e.g. spaces) then, in some browsers, UI can't find this publisher because non-URI characters are encoding to `%...` (e.g. `%20` for spaces).
As a result, we're seeing `[rempl][ws-transport] Publisher ... isn't registered on page` error in Firefox and Safari.
In this PR we're decoding publisher name from URL