### PR TITLE
add browser filed for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.18",
   "description": "Рlatform for moderated remote access to JavaScript runtime via custom UI",
   "main": "src/index.js",
+  "browser": "dist/rempl.js",
   "author": "Roman Dvornov",
   "contributors": [
     "Roman Dvornov <rdvornov@gmail.com>",


### PR DESCRIPTION
I didn't manage to build a project with webpack, since file under `main` field is supposed to be run in node environment. Adding `browser` field allows me to build project locally and use the result with `npm link`.
I haven't touched `.npmignore`, `.gitignore` since not sure how you want to configure them 